### PR TITLE
[Ink] Call `setNeedsLayout` after `maxRippleRadius` changes.

### DIFF
--- a/components/Ink/src/MDCInkView.m
+++ b/components/Ink/src/MDCInkView.m
@@ -81,7 +81,10 @@
 }
 
 - (void)setMaxRippleRadius:(CGFloat)radius {
-  self.inkLayer.maxRippleRadius = radius;
+  if (self.inkLayer.maxRippleRadius != radius) {
+    self.inkLayer.maxRippleRadius = radius;
+    [self setNeedsLayout];
+  }
 }
 
 - (BOOL)usesCustomInkCenter {


### PR DESCRIPTION
Fix an ink view bug. When its maxRippleRadius is changed, it needs to call -setNeedsLayout so its ink layer could call -layoutSublayers that re-calculate the ripple frame.

From internal change 169289257.